### PR TITLE
UI Compatibility + Spanish

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2,7 +2,7 @@
     "introduceMe": {
         "introduceDialog": {
             "title": "Introduce Me",
-            "flavorTitle": "Flavortext",
+            "flavorTitle": "Flavor Text",
             "colorsTitle": "Edit Actor Introduction Colors",
             "durationTitle": "Introduction Duration",
             "preview": "Private Preview",
@@ -29,7 +29,8 @@
             "template": "Template",
             "backgroundLabel": "Background Color",
             "textLabel": "Text Color",
-            "clipsLabel": "Show Clips"
+            "clipsLabel": "Show Clips",
+	    "tester": "Color Tester"
         },
         "colorTemplates": {
             "name": "Color Templates",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,0 +1,62 @@
+{
+    "introduceMe": {
+        "introduceDialog": {
+            "title": "Pres\u00E9ntame",
+            "flavorTitle": "Texto Adicional",
+            "colorsTitle": "Editar colores de Presentaci\u00F3n del Actor",
+            "durationTitle": "Duraci\u00F3n de la Presentaci\u00F3n",
+            "preview": "Vista Previa Privada",
+            "save": "Guardar Ajustes",
+            "introduce": "Presentar",
+            "noneDefault": "El actor no tiene colores predeterminados",
+            "default": "Reiniciar a predeterminados",
+            "actorColorSettings": "Ajustes de Color del Actor"
+        },
+        "settings": {
+            "title": "Ajustes"
+        },
+        "colorSettings": {
+            "name": "Colores de la Presentaci\u00F3n",
+            "label": "Ajustes de Color",
+            "default": "Reiniciar a colores predeterminados",
+            "preview": "Vista Previa Privada",
+            "save": "Guardar",
+            "actor": "Actor",
+            "players": "Jugador",
+            "friendly": "Amistoso",
+            "neutral": "Neutral",
+            "hostile": "Hostil",
+            "template": "Plantilla",
+            "backgroundLabel": "Color de Fondo",
+            "textLabel": "Color de Texto",
+            "clipsLabel": "Mostrar Clips",
+	    "tester": "Prueba de Color"
+        },
+        "colorTemplates": {
+            "name": "Plantillas de Color",
+            "label": "Plantillas de Color",
+            "newTemplatePlaceholder": "Nuevo nombre de plantilla..",
+            "create": "Crear Nueva Plantilla"
+        },
+        "HUD": {
+            "introduceButton": "Pres\u00E9ntame"
+        },
+        "gameSettings": {
+            "showHud": {
+                "name": "Mostrar HUD",
+                "hint": "Si el HUD no se muestra, entonces usar las macros del m\u00F3dulo para acceder a la funcionalidad."
+            },
+            "useToken": {
+                "name": "Usar Iconos",
+                "hint": "Mostrar el icono del actor en lugar del avatar en la Presentaci\u00F3n."
+            },
+            "introductionDuration": {
+                "name": "Duraci\u00F3n Predeterminada de la Presentaci\u00F3n",
+                "hint": "La duraci\u00F3n predeterminada en segundos que la Presentaci\u00F3n permanecer\u00E1 tras el fin de la animaci\u00F3n antes de ser eliminada."
+            },
+            "introductionColors": {
+                "name": "Colores de la Presentaci\u00F3n"
+            }
+        }
+    }
+}

--- a/module.json
+++ b/module.json
@@ -7,29 +7,34 @@
         "introduce-me.js",
         "greensock/esm/all.js"
     ],
-     "styles": [
-         "introduce-me.css"
-     ],
+    "styles": [
+        "introduce-me.css"
+    ],
     "languages": [
         {
             "lang": "en",
             "name": "English",
             "path": "lang/en.json"
+        },
+        {
+            "lang": "es",
+            "name": "Español",
+            "path": "lang/es.json"
         }
     ],
     "packs": [
-		{
-			"name": "introduce-me",
-			"label": "Introduce Me",
-			"path": "./packs/introduce-me.db",
-			"entity": "Macro"
-		}
-	],
+        {
+            "name": "introduce-me",
+            "label": "Introduce Me",
+            "path": "./packs/introduce-me.db",
+            "entity": "Macro"
+        }
+    ],
     "socket": true,
     "version": "0.9.2.1",
     "minimumCoreVersion": "8",
-    "compatibleCoreVersion":"9",
+    "compatibleCoreVersion": "9",
     "url": "https://github.com/WBHarry/introduce-me",
     "manifest": "https://github.com/WBHarry/introduce-me/releases/latest/download/module.json",
-    "download": "https://github.com/WBHarry/introduce-me/releases/latest/download/module.zip"
-  }
+    "download": "https://github.com/WBHarry/introduce-me/releases/download/0.9.2.1/module.zip"
+}

--- a/modules/Introduction.js
+++ b/modules/Introduction.js
@@ -86,11 +86,11 @@ export default class Introduction {
 
     editDisplay = async (colors, localToken, localActor) => {
         $(document.body).find('.introduce-me.introduction').remove();
-        const flavor = localActor?.getFlag('introduce-me', 'flavor') ?? 'Flavortext';
+        const flavor = localActor?.getFlag('introduce-me', 'flavor') ?? game.i18n.localize("introduceMe.introduceDialog.flavorTitle");
 
         $(document.body).append($(await renderTemplate('modules/introduce-me/templates/introduction.hbs', { 
             token: localToken ?? {
-                name: 'Color Tester'
+                name: game.i18n.localize("introduceMe.colorSettings.tester")
             }, 
             img: localActor ? this.getIntroductionImage(localToken, localActor) : 'icons/svg/cowled.svg', 
             flavor: flavor,

--- a/templates/colorTemplates.hbs
+++ b/templates/colorTemplates.hbs
@@ -1,6 +1,6 @@
 <form class="introduce-me color-templates" autocomplete="off">
     <header>
-        <input class="flex0" name="newTemplateName" value="{{this.newTemplateName}}" type="text" data-dtype="text" placeholder="{{localize "introduceMe.colorTemplates.newTemplatePlaceholder"}}" />
+        <input class="flex0 input" name="newTemplateName" value="{{this.newTemplateName}}" type="text" data-dtype="text" placeholder="{{localize "introduceMe.colorTemplates.newTemplatePlaceholder"}}" />
         <button class="flex0 color-template-create" {{#unless this.createTemplateDisabled}}title="{{localize "introduceMe.colorTemplates.create"}}"{{/unless}} {{disabled this.createTemplateDisabled}}><i class="fas fa-plus"></i></button>
     </header>
     <content>

--- a/templates/introduceDialog.hbs
+++ b/templates/introduceDialog.hbs
@@ -3,14 +3,14 @@
         <div class="setting">
             <label><strong>{{localize "introduceMe.introduceDialog.flavorTitle"}}</strong></label>
             <div class="flexrow input-row">
-                <input class="flex1" name="flavor" value="{{this.flavor}}" type="text" data-dtype="string" />
+                <input class="flex1 flavor-input" name="flavor" value="{{this.flavor}}" type="text" data-dtype="string"/>
                 <div class="flex0 default-button"></div>
             </div>
         </div>
         <div class="setting">
             <label><strong>{{localize "introduceMe.introduceDialog.colorsTitle"}}</strong></label>
             <div class="flexrow input-row">
-                <button id="color-setting"><i class="fas fa-palette"></i></button>
+                <button id="color-setting"><i class="fas fa-palette color-palette"></i></button>
                 {{#if this.isDefaultColor}}
                     <div class="flex0 default-button"></div>
                 {{else}}


### PR DESCRIPTION
Hi. Nice module you made!

I'm planning to use this module in my WFRP games, but it uses it's own UI and there are issues with this module. This PR is to make more inputs and buttons customizable via .css file.

So far the only thing I couldn't add are these color picker values.
![color picker](https://user-images.githubusercontent.com/87753744/173544646-93ca6048-d4d2-414a-a933-fd1d58c16267.jpg)
(This pick is made with a custom WFRP system .css file)

Also, I added a spanish translation and made the private preview translatable.

Note: I only added the spanish language to my module.json file.
