### PR TITLE
Api now accepts actors

### DIFF
--- a/introduce-me.js
+++ b/introduce-me.js
@@ -7,7 +7,7 @@ import IntroduceDialog from './modules/IntroduceDialog.js';
 
 Hooks.once('init', () => {
     game.modules.get("introduce-me").api = {
-        introduceMe: async (token) => await new Introduction().introduceMe(token, token.actor),
+        introduceMe: async (token, actor) => await new Introduction().introduceMe(token, actor ?? token.actor),
         introduceDialog: new Introduction().introduceMeDialog,
     };
     gsap.registerPlugin(SplitText);

--- a/modules/Introduction.js
+++ b/modules/Introduction.js
@@ -15,7 +15,7 @@ export default class Introduction {
 
     introduceMe = async (token, actor) => {
         if(game.user.isGM && token) {
-            await game.socket.emit(`module.introduce-me`, { type: RequestType.introduce, data: { uuid: token.document?.uuid ?? token.uuid } });
+            await game.socket.emit(`module.introduce-me`, { type: RequestType.introduce, data: { uuid: token.document?.uuid ?? token.uuid ?? actor.uuid } });
             await this.introductionDisplay(token, actor);
         }
     }

--- a/modules/SocketHandler.js
+++ b/modules/SocketHandler.js
@@ -4,8 +4,9 @@ export const setupSockets = async () => {
     game.socket.on(`module.introduce-me`, async request => {
         switch(request.type){
             case RequestType.introduce:
-                const token = await fromUuid(request.data.uuid);
-                await new Introduction().introductionDisplay(token, token.actor);
+                const entity = await fromUuid(request.data.uuid);
+                const token = entity.documentName === "Actor" ? entity.prototypeToken : entity;
+                const actor = entity.documentName === "Actor" ? entity : entity.actor;
                 break;
         }
     });


### PR DESCRIPTION
Hello,

Here is a simple modification to allow introducing actors with the API.

This way, we can hook into an actor sheet to add a button that executes the API command.
No effect whatsoever on previous uses of the same API command.

Exemple:
```js
api.introduceMe(actor._source.token, actor);
```